### PR TITLE
bug fix handle command.AsError(err) function call gracefully

### DIFF
--- a/git/api/commit.go
+++ b/git/api/commit.go
@@ -565,7 +565,7 @@ func (g *Git) GetFullCommitID(
 	output := &bytes.Buffer{}
 	err := cmd.Run(ctx, command.WithDir(repoPath), command.WithStdout(output))
 	if err != nil {
-		if command.AsError(err).IsExitCode(128) {
+		if eErr := command.AsError(err); eErr != nil && eErr.IsExitCode(128) {
 			return sha.None, errors.NotFound("commit not found %s", shortID)
 		}
 		return sha.None, err

--- a/git/api/merge.go
+++ b/git/api/merge.go
@@ -70,7 +70,8 @@ func (g *Git) GetMergeBase(
 		// git merge-base rev1 rev2
 		// if there is unrelated history then stderr is empty with
 		// exit code 1. This cannot be handled in processGitErrorf because stderr is empty.
-		if command.AsError(err).IsExitCode(1) && stderr.Len() == 0 {
+		cmdErr := command.AsError(err)
+		if cmdErr != nil && cmdErr.IsExitCode(1) && stderr.Len() == 0 {
 			return sha.None, "", &UnrelatedHistoriesError{
 				BaseRef: base,
 				HeadRef: head,

--- a/git/api/rev.go
+++ b/git/api/rev.go
@@ -32,7 +32,7 @@ func (g *Git) ResolveRev(ctx context.Context,
 	output := &bytes.Buffer{}
 	err := cmd.Run(ctx, command.WithDir(repoPath), command.WithStdout(output))
 	if err != nil {
-		if command.AsError(err).IsAmbiguousArgErr() {
+		if eErr := command.AsError(err); eErr != nil && eErr.IsAmbiguousArgErr() {
 			return sha.None, errors.InvalidArgument("could not resolve git revision: %s", rev)
 		}
 		return sha.None, fmt.Errorf("failed to resolve git revision: %w", err)

--- a/git/sharedrepo/sharedrepo.go
+++ b/git/sharedrepo/sharedrepo.go
@@ -241,7 +241,7 @@ func (r *SharedRepo) GetTreeSHA(
 		command.WithStdout(stdout),
 	)
 	if err != nil {
-		if command.AsError(err).IsAmbiguousArgErr() {
+		if cErr := command.AsError(err); cErr != nil && cErr.IsAmbiguousArgErr() {
 			return sha.None, errors.NotFound("could not resolve git revision %q", rev)
 		}
 		return sha.None, fmt.Errorf("failed to get tree sha: %w", err)


### PR DESCRIPTION
Protect against nil exception

Occurred when importing multiple repos from an organization and some repo imports failed.
This specific error was on facebook/create-react-app repo.

_Note: couldn't cleanly reproduce it with a minimal test at this point._

Stack trace
================================================
08:57:42.487 INF http request completed. http.elapsed_ms=42.596625 http.method=GET http.response_size_bytes=48 http.router=api http.status_code=500 http.url=/v1/repos/react%2Fcreate-react-app/summary? principal_admin=true principal_type=user principal_uid=admin request_id=cu7t41m5do0naaovtu3g

 panic: runtime error: invalid memory address or nil pointer dereference
 
 -> github.com/harness/gitness/git/command.(*Error).Error
 ->   ./harness/git/command/error.go:65

    github.com/harness/gitness/git/command.(*Error).IsAmbiguousArgErr
      ./harness/git/command/error.go:57
    github.com/harness/gitness/git/api.(*Git).ResolveRev
      ./harness/git/api/rev.go:35
    github.com/harness/gitness/git/api.(*Git).PathsDetails
      ./harness/git/api/paths_details.go:34
    github.com/harness/gitness/git.(*Service).PathsDetails
      ./harness/git/tree.go:207
    github.com/harness/gitness/app/api/controller/repo.(*Controller).PathsDetails
      ./harness/app/api/controller/repo/content_paths_details.go:62
    github.com/harness/gitness/app/api/handler/repo.HandlePathsDetails.func1
      ./harness/app/api/handler/repo/content_paths_details.go:46
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:459
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:73
    github.com/go-chi/chi/v5.(*Mux).Mount.func1
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:327
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:459
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:73
    github.com/go-chi/chi/v5.(*Mux).Mount.func1
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:327
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.func1.1.Attempt.1.1
      ./harness/app/api/middleware/authn/authn.go:62
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/chain.go:31
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:459
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:73
    github.com/go-chi/chi/v5.(*Mux).Mount.func1
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:327
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:459
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.Middleware.func7.1
      ./harness/audit/middleware.go:44
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/cors.(*Cors).Handler-fm.(*Cors).Handler.func1
      /Users/<user>/go/pkg/mod/github.com/go-chi/cors@v1.2.1/cors.go:228
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.Handler.func6.1
      ./harness/app/api/middleware/address/address.go:46
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.HLogAccessLogHandler.AccessHandler.func10.1
      /Users/<user>/go/pkg/mod/github.com/rs/zerolog@v1.33.0/hlog/hlog.go:300
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.HLogRequestIDHandler.func4.1
      ./harness/app/api/middleware/logging/logging.go:61
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.MethodHandler.func3.1
      /Users/<user>/go/pkg/mod/github.com/rs/zerolog@v1.33.0/hlog/hlog.go:59
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.NewAPIHandler.URLHandler.func2.1
      ./harness/app/api/middleware/logging/logging.go:89
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5/middleware.Recoverer.func1
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/middleware/recoverer.go:45
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/api/middleware/nocache.NoCache.func1
      ./harness/app/api/middleware/nocache/nocache.go:44
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /Users/<user>/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.12/mux.go:90
    github.com/harness/gitness/app/router.NewAPIHandler.TerminatedPathBefore.func8
      ./harness/app/api/middleware/encode/encode.go:121
    net/http.HandlerFunc.ServeHTTP
      /usr/local/go/src/net/http/server.go:2220
    github.com/harness/gitness/app/router.(*APIRouter).Handle
      ./harness/app/router/api_router.go:47
    github.com/harness/gitness/app/router.(*Router).ServeHTTP
      ./harness/app/router/router.go:60
    net/http.serverHandler.ServeHTTP
      /usr/local/go/src/net/http/server.go:3210
    net/http.(*conn).serve
      /usr/local/go/src/net/http/server.go:2092
    created by net/http.(*Server).Serve in goroutine 88
      /usr/local/go/src/net/http/server.go:3360
    
09:00:00.014 TRC job scheduler: started 1 jobs; next iteration in 30m0s